### PR TITLE
Fix compatibility with MySQL 5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/dmarcts-report-parser.conf

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -658,7 +658,7 @@ sub checkDatabase {
 			column_definitions 		=> [
 				"serial"		, "int(10) unsigned NOT NULL AUTO_INCREMENT",
 				"mindate"		, "timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
-				"maxdate"		, "timestamp NOT NULL DEFAULT '0000-00-00 00:00:00'",
+				"maxdate"		, "timestamp NULL",
 				"domain"		, "varchar(255) NOT NULL",
 				"org"			, "varchar(255) NOT NULL",
 				"reportid"		, "varchar(255) NOT NULL",


### PR DESCRIPTION
MySQL 5.7 is a little stricter - meaning per default it does not allow `0000-00-00 00:00:00` in date fields. Seems like there is no reason not to set the default to `NULL` in this case anyways.