### PR TITLE
Fix mbox bug and a few other things

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ $imapreadfolder = 'Inbox';
 # If $imapmovefolder is set, processed IMAP messages
 # will be moved (overruled by the --delete option!)
 $imapmovefolder = 'Inbox.processed';
+
+# maximum size of XML files to store in database, long files can cause transaction aborts
+$maxsize_xml = 50000;
+# store XML as base64 encopded gzip in database (save space, harder usable)
+$compress_xml = 0;
+
+# if there was an error during file processing (message does not contain XML or ZIP parts, 
+# or a database error) the parser reports an error and does not delete the file, even if 
+# delete_reports is set (or --delete is given). Deletion can be enforced by delete_failed, 
+# however not for database errors.
+$delete_failed = 0;
 ```
 The script is looking for `dmarcts-report-parser.conf` in the current working directory. If not found it will look by the calling path. If neither is found than it will abort.
 

--- a/dmarcts-report-parser.conf.sample
+++ b/dmarcts-report-parser.conf.sample
@@ -28,5 +28,9 @@ $imapmovefolder = 'Inbox.processed';
 $maxsize_xml = 50000;
 # store XML as base64 encopded gzip in database (save space, harder usable)
 $compress_xml = 0;
-# delete failed files (no XML, database errors)
+
+# if there was an error during file processing (message does not contain XML or ZIP parts, 
+# or a database error) the parser reports an error and does not delete the file, even if 
+# delete_reports is set (or --delete is given). Deletion can be enforced by delete_failed, 
+# however not for database errors.
 $delete_failed = 0;

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -197,11 +197,8 @@ if ($reports_source == TS_IMAP) {
 	# unwanted side effects.
 	$imap->Uid(1);
 
-	if ($debug) {
-		# How many msgs are we going to process?
-		print "There are ". $imap->message_count($imapreadfolder).
-			" messages in folder <$imapreadfolder>.\n";
-	}
+	# How many msgs are we going to process?
+	print "Processing ". $imap->message_count($imapreadfolder)." messages in folder <$imapreadfolder>.\n" if $debug;
 
 	# Only select and search $imapreadfolder, if we actually
 	# have something to do.
@@ -259,6 +256,7 @@ if ($reports_source == TS_IMAP) {
 
 } else { # TS_MESSAGE_FILE or TS_XML_FILE or TS_MBOX_FILE
 
+	my $counts = 0;
 	foreach my $a (@ARGV) {
 		# Linux bash supports wildcard expansion BEFORE the script is
 		# called, so here we only see a list of files. Other OS behave
@@ -281,6 +279,7 @@ if ($reports_source == TS_IMAP) {
 							# processXML return a value with delete bit enabled
 							print "Removing message #$num from mbox file <$f> is not yet supported.\n";
 						}
+						$counts++;
 					}
 				} while(defined($filecontent));
 
@@ -295,12 +294,14 @@ if ($reports_source == TS_IMAP) {
 						# processXML return a value with delete bit enabled
 						unlink($f);
 					}
+					$counts++;
 				} elsif ($reports_source == TS_XML_FILE) {
 					# filecontent is xml file
 					if (processXML(TS_XML_FILE, $filecontent, "xml file <$f>") & 2) {
 						# processXML return a value with delete bit enabled
 						unlink($f);
 					}
+					$counts++;
 				} else {
 					print "Unknown reports_source <$reports_source> for file <$f>. Skipped.\n";
 				}
@@ -314,6 +315,7 @@ if ($reports_source == TS_IMAP) {
 			}
 		}
 	}
+	print "Processed $counts messages(s).\n" if $debug;
 }
 
 

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -155,7 +155,7 @@ if (exists $options{x}) {
 if (exists $options{m}) {
 	if ($reports_source == TS_IMAP) {
 		die "The -m OPTION requires a PATH.\n";
-	} elsif ($reports_source == TS_IMAP) {
+	} elsif ($reports_source == TS_XML_FILE) {
 		die "The -m and -x OPTIONS cannot be used both.\n";
 	} else {
 		$reports_source = TS_MBOX_FILE;
@@ -197,10 +197,10 @@ if ($reports_source == TS_IMAP) {
 	# unwanted side effects.
 	$imap->Uid(1);
 
-	if ($debug == 1) {
+	if ($debug) {
 		# How many msgs are we going to process?
 		print "There are ". $imap->message_count($imapreadfolder).
-			" messages in the $imapreadfolder folder.\n";
+			" messages in folder <$imapreadfolder>.\n";
 	}
 
 	# Only select and search $imapreadfolder, if we actually
@@ -216,45 +216,17 @@ if ($reports_source == TS_IMAP) {
 
 		# Loop through IMAP messages.
 		foreach my $msg (@msgs) {
-			if ($debug == 1) {
-				print "--------------------------------\n";
-				print "The Current Message UID is: ";
-				print $msg. "\n";
-				print "--------------------------------\n";
-			}
 
-			my $xml = getXMLFromMessage($imap->message_string($msg),"IMAP message with UID #".$msg);
-			# If !$xml, the mail is probably not a DMARC report, so
-			# do not storeXMLInDatabase.
-			if ($xml) {
-				# If storeXMLInDatabase returns false, there was some sort
-				# of database storage failure and we MUST stop the file
-				# procession, because it is not pushed into the database.
-				# The user must investigate this issue.
-				if (storeXMLInDatabase($xml) <= 0) {
-					next;
-				}
-			}
-
-			# Delete processed message files, if the --delete option
-			# is given. Otherwise move msgs if $imapmovefolder is set.
-			if ($delete_reports && ($xml || $delete_failed)) {
-				if ($debug == 1) {
-					print "Deleting processed IMAP message file.\n";
-				}
-				if (!$xml) {
-					# A mail which does not look like a DMARC report
-					# has been processed and should now be deleted.
-					# Print its content so it gets send as cron
-					# message, so the user can still investigate.
-					print $imap->message_string($msg)."\n"
-				}
+			my $processResult = processXML(TS_MESSAGE_FILE, $imap->message_string($msg), "IMAP message with UID #".$msg);
+			if ($processResult & 4) {
+				# processXML returned a value with database error bit enabled, do nothing at all!
+				next;
+			} elsif ($processResult & 2) {
+				# processXML return a value with delete bit enabled.
 				$imap->delete_message($msg)
 				or print "Could not delete IMAP message. [$@]\n";
 			} elsif ($imapmovefolder) {
-				if ($debug == 1) {
-					print "Moving (copy and delete) processed IMAP message file to IMAP folder: $imapmovefolder\n";
-				}
+				print "Moving (copy and delete) processed IMAP message file to IMAP folder: $imapmovefolder\n" if $debug;
 
 				# Try to create $imapmovefolder, if it does not exist.
 				if (!$imap->exists($imapmovefolder)) {
@@ -285,7 +257,7 @@ if ($reports_source == TS_IMAP) {
 	# We're all done with IMAP here.
 	$imap->logout();
 
-} else { # TS_MESSAGE_FILE or TS_XML_FILE
+} else { # TS_MESSAGE_FILE or TS_XML_FILE or TS_MBOX_FILE
 
 	foreach my $a (@ARGV) {
 		# Linux bash supports wildcard expansion BEFORE the script is
@@ -294,86 +266,51 @@ if ($reports_source == TS_IMAP) {
 		# on each argument to manually expand the argument, if possible.
 		my @file_list = glob($a);
 
-		if ($debug == 1) {
-			# How many msgs are we going to process?
-			print "There are ". @file_list. " messages to be processed.\n";
-		}
-
 		foreach my $f (@file_list) {
-			if ($debug == 1) {
-				print "--------------------------------\n";
-				print "The Current Message is: ";
-				print $f. "\n";
-				print "--------------------------------\n";
-			}
-
-			my $xml;
 			my $filecontent;
-			my $err = 0;
+
 			if ($reports_source == TS_MBOX_FILE) {
-				 my $parser = Mail::Mbox::MessageParser->new({"file_name" => $f, "debug" => $debug, "enable_cache" => 0});
-				 my $num = 1;
-				 do {
+				my $parser = Mail::Mbox::MessageParser->new({"file_name" => $f, "debug" => $debug, "enable_cache" => 0});
+				my $num = 0;
+
+				do {
+					$num++;
 					$filecontent = $parser->read_next_email();
-					if ($filecontent) {
-						my $mboxxml = getXMLFromMessage($filecontent,"$f message $num");
-						if($mboxxml && storeXMLInDatabase($mboxxml) <= 0) {
-							$err = 1;
+					if (defined($filecontent)) {
+						if (processXML(TS_MESSAGE_FILE, $$filecontent, "message #$num of mbox file <$f>") & 2) {
+							# processXML return a value with delete bit enabled
+							print "Removing message #$num from mbox file <$f> is not yet supported.\n";
 						}
 					}
-					++$num;
-				} while (defined($filecontent));
+				} while(defined($filecontent));
+
 			} elsif (open FILE, $f) {
+
 				$filecontent = join("", <FILE>);
 				close FILE;
+
 				if ($reports_source == TS_MESSAGE_FILE) {
-					# Get XML data from mime message.
-					$xml = getXMLFromMessage($filecontent,$f);
-				} else {
-					# Get XML data from XML file directly.
-					$xml = getXMLFromXMLString($filecontent);
-					if (!$xml) {
-						print "File <$f> does not seem to be a valid XML file. Skipped.\n";
+					# filecontent is a mime message with zip or xml part
+					if (processXML(TS_MESSAGE_FILE, $filecontent, "message file <$f>") & 2) {
+						# processXML return a value with delete bit enabled
+						unlink($f);
 					}
+				} elsif ($reports_source == TS_XML_FILE) {
+					# filecontent is xml file
+					if (processXML(TS_XML_FILE, $filecontent, "xml file <$f>") & 2) {
+						# processXML return a value with delete bit enabled
+						unlink($f);
+					}
+				} else {
+					print "Unknown reports_source <$reports_source> for file <$f>. Skipped.\n";
 				}
+
 			} else {
 				print "Could not open file <$f>: $!. Skipped.\n";
-				# Could not retrieve filecontent, so it is not
-				# possible to --delete file and send filecontent
-				# as cron message. The user has to look at the
-				# actual file. The skipped message must be send
-				# on each cron.
-				next;
-			}
-
-			# If !$xml, the file/mail is probably not a DMARC report.
-			# So do not storeXMLInDatabase.
-			if ($xml) {
-				# If storeXMLInDatabase returns false, there was some sort
-				# of database storage failure and we MUST stop the file
-				# procession, because it is not pushed into the database.
-				# The user must investigate this issue.
-				if (storeXMLInDatabase($xml) <= 0) {
-					next;
-				}
-			} else {
-				$err = 1;
-			}
-
-			# Delete processed message files, if the --delete option
-			# is given.
-			if ($delete_reports && (!$err || $delete_failed)) {
-				if (!$xml) {
-					# A mail which does not look like a DMARC report
-					# has been processed and should now be deleted.
-					# Print its content so it gets send as cron
-					# message, so the user can still investigate.
-					print $filecontent."\n"
-				}
-				if($debug) {
-					print "Remove file <$f>.\n";
-				}
-				unlink($f);
+				# Could not retrieve filecontent, the skipped message
+				# will be processed every time the script is run even if
+				# delete_reports and delete_failed is given. The user
+				# has to look at the actual file.
 			}
 		}
 	}
@@ -385,12 +322,66 @@ if ($reports_source == TS_IMAP) {
 ### subroutines ################################################################
 ################################################################################
 
+sub processXML {
+	my $type = $_[0];
+	my $filecontent = $_[1];
+	my $f = $_[2];
+
+	if ($debug) {
+		print "\n";
+		print "----------------------------------------------------------------\n";
+		print "Processing $f \n";
+		print "----------------------------------------------------------------\n";
+	}
+
+	my $xml; #TS_XML_FILE or TS_MESSAGE_FILE
+	if ($type == TS_MESSAGE_FILE) {$xml = getXMLFromMessage($filecontent);}
+	else {$xml = getXMLFromXMLString($filecontent);}
+
+	# If !$xml, the file/mail is probably not a DMARC report.
+	# So do not storeXMLInDatabase.
+	if ($xml && storeXMLInDatabase($xml) <= 0) {
+		# If storeXMLInDatabase returns false, there was some sort
+		# of database storage failure and we MUST NOT delete the
+		# file, because it has not been pushed into the database.
+		# The user must investigate this issue.
+		print "Skipping $f due to database errors.\n";
+		return 5; #xml ok(1), but database error(4), thus no delete (!2)
+	}
+
+	# Delete processed message, if the --delete option
+	# is given. Failed reports are only deleted, if delete_failed is given.
+	if ($delete_reports && ($xml || $delete_failed)) {
+		if ($xml) {
+			print "Removing after report has been processed." if $debug;
+			return 3; #xml ok (1), delete file (2)
+		} else {
+			# A mail which does not look like a DMARC report
+			# has been processed and should now be deleted.
+			# Print its content so it gets send as cron
+			# message, so the user can still investigate.
+			print "The $f does not seem to contain a valid DMARC report. Skipped and Removed. Content:\n";
+			print $filecontent."\n";
+			return 2; #xml not ok (!1), delete file (2)
+		}
+	}
+
+	if ($xml) {
+		return 1;
+	} else {
+		print "The $f does not seem to contain a valid DMARC report. Skipped.\n";
+		return 0;
+	}
+}
+
+
+################################################################################
+
 # Walk through a mime message and return a reference to the XML data containing
 # the fields of the first ZIPed XML file embedded into the message. The XML
 # itself is not checked to be a valid DMARC report.
 sub getXMLFromMessage {
 	my $message = $_[0];
-	my $messagefile = $_[1];
 
 	my $parser = new MIME::Parser;
 	$parser->output_dir("/tmp");
@@ -401,7 +392,7 @@ sub getXMLFromMessage {
 	my $mtype = $ent->mime_type;
 	my $subj = decode_mimewords($ent->get('subject'));
 
-	if ($debug == 1) {
+	if ($debug) {
 		print "Subject: $subj"; # Subject always contains a \n.
 		print "MimeType: $mtype\n";
 	}
@@ -410,14 +401,14 @@ sub getXMLFromMessage {
 	my $isgzip = 0;
 
 	if(lc $mtype eq "application/zip") {
-		if ($debug == 1) {
+		if ($debug) {
 			print "This is a ZIP file \n";
 		}
 
 		$location = $body->path;
 
 	} elsif (lc $mtype eq "application/gzip") {
-		if ($debug == 1) {
+		if ($debug) {
 			print "This is a GZIP file \n";
 		}
 
@@ -427,7 +418,7 @@ sub getXMLFromMessage {
 	} elsif (lc $mtype eq "multipart/mixed") {
 		# At the moment, nease.net messages are multi-part, so we need
 		# to breakdown the attachments and find the zip.
-		if ($debug == 1) {
+		if ($debug) {
 			print "This is a multipart attachment \n";
 		}
 		#print Dumper($ent->parts);
@@ -453,7 +444,7 @@ sub getXMLFromMessage {
 				print "$location\n" if $debug;
 			} else {
 				# Skip the attachment otherwise.
-				if($debug == 1) {
+				if ($debug) {
 					print "Skipped an unknown attachment \n";
 				}
 				next; # of parts
@@ -463,7 +454,7 @@ sub getXMLFromMessage {
 		## Clean up dangling mime parts in /tmp of messages without ZIP.
 		my $num_parts = $ent->parts;
 		for (my $i=0; $i < $num_parts; $i++) {
-			if($debug == 1) {
+			if ($debug) {
 				if ($ent->parts($i)->{ME_Bodyhandle} && $ent->parts($i)->{ME_Bodyhandle}->{MB_Path}) {
 					print $ent->parts($i)->{ME_Bodyhandle}->{MB_Path};
 				} else {
@@ -479,7 +470,7 @@ sub getXMLFromMessage {
 	# If a ZIP has been found, extract XML and parse it.
 	my $xml;
 	if(defined($location)) {
-		if ($debug == 1) {
+		if ($debug) {
 			print "body is in " . $location . "\n";
 		}
 
@@ -505,14 +496,14 @@ sub getXMLFromMessage {
 		if ($unzip eq "") {
 			$xml = getXMLFromXMLString(join("", <XML>));
 			if (!$xml) {
-				print "The XML found in ZIP file (temp. location: <$location>) extracted from <$messagefile> does not seem to be valid XML. Skipped.\n";
+				print "The XML found in ZIP file (temp. location: <$location>) does not seem to be valid XML! ";
 			}
 			close XML;
 		} else {
-			print "Failed to $unzip ZIP file (temp. location: <$location>) extracted from <$messagefile>. Skipped.\n";
+			print "Failed to $unzip ZIP file (temp. location: <$location>)! ";
 		}
 	} else {
-		print "Could not find an embedded ZIP in <$messagefile>. Skipped.\n";
+		print "Could not find an embedded ZIP! ";
 	}
 
 	if($body) {$body->purge;}
@@ -607,7 +598,7 @@ sub storeXMLInDatabase {
 	}
 
 	my $serial = $dbh->{'mysql_insertid'} ||  $dbh->{'insertid'};
-	if($debug == 1){
+	if ($debug){
 		print " serial $serial ";
 	}
 	my $record = $xml->{'record'};
@@ -657,7 +648,7 @@ sub storeXMLInDatabase {
 
 		# What type of IP address?
 		my ($nip, $iptype, $ipval);
-		if($debug == 1) {
+		if ($debug) {
 			print "ip=$ip\n";
 		}
 		if($nip = inet_pton(AF_INET, $ip)) {
@@ -682,12 +673,12 @@ sub storeXMLInDatabase {
 
 	my $res = 1;
 	if(ref $record eq "HASH") {
-		if($debug == 1){
+		if ($debug){
 			print "single record\n";
 		}
 		$res = -1 if !dorow($serial,$record);
 	} elsif(ref $record eq "ARRAY") {
-		if($debug == 1){
+		if ($debug){
 			print "multi record\n";
 		}
 		foreach my $row (@$record) {

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -355,7 +355,7 @@ sub processXML {
 	# is given. Failed reports are only deleted, if delete_failed is given.
 	if ($delete_reports && ($xml || $delete_failed)) {
 		if ($xml) {
-			print "Removing after report has been processed." if $debug;
+			print "Removing after report has been processed.\n" if $debug;
 			return 3; #xml ok (1), delete file (2)
 		} else {
 			# A mail which does not look like a DMARC report
@@ -583,14 +583,15 @@ sub storeXMLInDatabase {
 	if ($compress_xml) {
 		my $gzipdata;
 		if(!gzip(\$storexml => \$gzipdata)) {
-			print "Cannot add gzip XML for database ($GzipError). Skipped.\n";
+			print "Cannot add gzip XML to database ($GzipError). Skipped.\n";
+			return 0;
 			$storexml = "";
 		} else {
 			$storexml = encode_base64($gzipdata, "");
 		}
 	}
 	if (length($storexml) > $maxsize_xml) {
-		print "Skipping storage of large XML (".length($storexml)." bytes).\n";
+		print "Skipping storage of large XML (".length($storexml)." bytes) as defined in config file.\n";
 		$storexml = "";
 	}
 	$dbh->do($sql, undef, $from, $to, $domain, $org, $id, $email, $extra, $policy_adkim, $policy_aspf, $policy_p, $policy_sp, $policy_pct, $storexml);


### PR DESCRIPTION
In the current version there is a problem with the -m option (mbox files) and the --delete option. If both are used, the script deletes the entire mbox file and not just the processed messages. I do not think this is correct, since the mbox file is sort of a container and must be present even if empty. Furthermore, if there was some sort of temporary database error and some messages could not be processed, they MUST NOT be deleted, so they can be processed later. 

The mbox parser we are currently using is read-only and thus cannot change the mbox file and thus cannot delete a single message, so my fix for now is to display "Removing message #$num from mbox file <$f> is not yet supported.\n" and do nothing at all. The next step would be to switch to another mbox parser, which can actually delete a message from the mbox file.

While fixing that bug, I moved all the processing stuff in a sub routine, so that IMAP, MBOX, MIMEMESSAGE and XML use the same processing code, which reduced lots of redundancy and improved readability.

I also changed some wordings and rewrote the options parsing to make clear, what actually happens. I also introduced the -i option (IMAP) and the -e option (MIME Email file), but did not change the default behavior: It still uses IMAP as source, if no option is given at all and uses MIME Email files as source, if a PATH is given, but no source option.