### PR TITLE
make tls verrify server cert default and also activate imap debug with $debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $imapuser = 'dmarcreports';
 $imappass = 'xxx';
 $imapssl = '0'; # If set to 1, remember to change server port to 993.
 $imaptls = '1'; # Enabled as the default and best-practice.
+$tlsverify = '1'; # Enable verify server cert as the default and best-practice.
 $imapreadfolder = 'Inbox';
 
 # If $imapmovefolder is set, processed IMAP messages

--- a/dmarcts-report-parser.conf.sample
+++ b/dmarcts-report-parser.conf.sample
@@ -18,6 +18,7 @@ $imapuser = 'dmarcreports';
 $imappass = 'xxx';
 $imapssl = '0'; # If set to 1, remember to change server port to 993.
 $imaptls = '1'; # Enabled as the default and best-practice.
+$tlsverify = '1'; # Enable verify server cert as the default and best-practice.
 $imapreadfolder = 'Inbox';
 
 # If $imapmovefolder is set, processed IMAP messages will be moved (overruled by

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -226,7 +226,7 @@ if ($reports_source == TS_IMAP) {
 		Starttls => $imapopt,
 		User => $imapuser,
 		Password => $imappass,
-		Debug=> $debug		
+		Debug=> $debug
   )
 	# module uses eval, so we use $@ instead of $!
 	or die "IMAP Failure: $@";

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -73,7 +73,7 @@ use Socket6;
 use PerlIO::gzip;
 use File::Basename ();
 use IO::Socket::SSL;
-
+#use IO::Socket::SSL 'debug3';
 
 
 
@@ -116,7 +116,7 @@ sub show_usage {
 # Define all possible configuration options.
 our ($debug, $delete_reports, $delete_failed, $reports_replace, $maxsize_xml, $compress_xml,
 	$dbname, $dbuser, $dbpass, $dbhost,
-	$imapserver, $imapuser, $imappass, $imapssl, $imaptls, $imapmovefolder, $imapreadfolder, $imapopt);
+	$imapserver, $imapuser, $imappass, $imapssl, $imaptls, $imapmovefolder, $imapreadfolder, $imapopt, $tlsverify);
 
 # defaults
 $maxsize_xml 	= 50000;
@@ -215,7 +215,13 @@ if ($reports_source == TS_IMAP) {
 
 	# Disable verify mode for TLS support.
 	if ($imaptls == 1) {
-		$imapopt = [ SSL_verify_mode => SSL_VERIFY_NONE ];
+    if ( $tlsverify == 0 ) {
+      print "use tls without verify servercert.\n" if $debug;
+      $imapopt = [ SSL_verify_mode => SSL_VERIFY_NONE ];
+    } else {
+      print "use tls with verify servercert.\n" if $debug;
+      $imapopt = [ SSL_verify_mode => SSL_VERIFY_PEER ];
+    }
 	}
 
   

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -72,7 +72,7 @@ use Socket;
 use Socket6;
 use PerlIO::gzip;
 use File::Basename ();
-
+use IO::Socket::SSL;
 
 
 
@@ -142,6 +142,11 @@ if ( substr($conf_file, 0, 1) ne '/'  and substr($conf_file, 0, 1) ne '.') {
 my $conf_return = do $conf_file;
 die "couldn't parse $conf_file: $@" if $@;
 die "couldn't do $conf_file: $!"    unless defined $conf_return;
+
+# check config
+if (!defined $imapreadfolder ) {
+  die "\$imapreadfolder not defined. Check config file";
+}
   
 # Get command line options.
 my %options = ();
@@ -210,7 +215,7 @@ if ($reports_source == TS_IMAP) {
 
 	# Disable verify mode for TLS support.
 	if ($imaptls == 1) {
-		$imapopt = [ SSL_verify_mode => 0 ];
+		$imapopt = [ SSL_verify_mode => SSL_VERIFY_NONE ];
 	}
 
 	# Setup connection to IMAP server.

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -218,12 +218,16 @@ if ($reports_source == TS_IMAP) {
 		$imapopt = [ SSL_verify_mode => SSL_VERIFY_NONE ];
 	}
 
+  
+
 	# Setup connection to IMAP server.
 	my $imap = Mail::IMAPClient->new( Server => $imapserver,
 		Ssl => $imapssl,
 		Starttls => $imapopt,
 		User => $imapuser,
-		Password => $imappass)
+		Password => $imappass,
+		Debug=> $debug		
+  )
 	# module uses eval, so we use $@ instead of $!
 	or die "IMAP Failure: $@";
 


### PR DESCRIPTION
Even though I could not help with the google problem I think it is nice to active imap debugging if $debug set.

Making it as default to verify the server cert against MITM should be the default as best security practice. If somes uses selfsigned certfificates he can deactivate it with $tlsverify ='0';