### PR TITLE
Add table compression to create statement

### DIFF
--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -779,7 +779,7 @@ sub checkDatabase {
 				"raw_xml"		, "mediumtext",
 				],
 			additional_definitions 		=> "PRIMARY KEY (serial), UNIQUE KEY domain (domain,reportid)",
-			table_options			=> "",
+			table_options			=> "ROW_FORMAT=COMPRESSED",
 			},
 		"rptrecord" =>{
 			column_definitions 		=> [


### PR DESCRIPTION
The key size for the report table is too large, so must be compressed.