### PR TITLE
Resolves Issue  #59

### DIFF
--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -801,7 +801,7 @@ sub checkDatabase {
 				"dkim_align"		, "enum('fail','pass','unknown') NOT NULL",
 				"identifier_hfrom"	, "varchar(255)",
 				],
-			additional_definitions 		=> "PRIMARY KEY (id), KEY serial (serial,ip), KEY serial6 (serial,ip6)",
+			additional_definitions 		=> "KEY serial (serial,ip), KEY serial6 (serial,ip6)",
 			table_options			=> "",
 			},
 	);


### PR DESCRIPTION
No need to have two primary keys. I've selected ID as the primary key. In the report column, serial is listed as the primary key.