### PR TITLE
Fixed Exchange compatiblity, added IMAP port option, and other fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,36 +41,38 @@ git clone https://github.com/techsneeze/dmarcts-report-parser.git
 or download a zip file containg all files from [here](https://github.com/techsneeze/dmarcts-report-parser/archive/master.zip). Once the files have been downloaded, you will need to copy/rename `dmarcts-report-parser.conf.sample` to `dmarcts-report-parser.conf`. Next, edit the configuration options:
 
 ```
-####################################################################
-### configuration ##################################################
-####################################################################
+################################################################################
+### configuration ##############################################################
+################################################################################
 
-# If IMAP access is not used, config options starting with $imap
-# do not need to be set and are ignored.
+# If IMAP access is not used, config options starting with $imap do not need to
+# be set and are ignored.
 
 $debug = 0;
 $delete_reports = 0;
 
 $dbname = 'dmarc';
 $dbuser = 'dmarc';
-$dbpass = 'xxx';
-$dbhost = ''; # Set the hostname if we can't connect to the local socket.
+$dbpass = 'password';
+$dbhost = 'dbhost'; # Set the hostname if we can't connect to the local socket.
+$dbport = '3306';
 
-$imapserver       = 'mail.example.com:143';
-$imapuser         = 'dmarcreports';
-$imappass         = 'xxx';
-$imapssl          = '0';        # If set to 1, remember to change server port to 993 and to disable imaptls.
-$imaptls          = '1';        # Enabled as the default and best-practice.
-$tlsverify        = '1';        # Enable verify server cert as the default and best-practice.
-$imapignoreerror  = 0;          # set it to 1 if you see an "ERROR: message_string() 
+$imapserver       = 'imap.server';
+$imapuser         = 'username';
+$imappass         = 'password';
+$imapport         = '143';
+$imapssl          = '0';        # If set to 1, remember to change server port to 993 and disable imaptls.
+$imaptls          = '0';        # Enabled as the default and best-practice.
+$tlsverify        = '0';        # Enable verify server cert as the default and best-practice.
+$imapignoreerror  = '0';          # set it to 1 if you see an "ERROR: message_string() 
                                 # expected 119613 bytes but received 81873 you may 
                                 # need the IgnoreSizeErrors option" because of malfunction
                                 # imap server as MS Exchange 2007, ...
-$imapreadfolder = 'Inbox';
+$imapreadfolder   = 'dmarc';
 
-# If $imapmovefolder is set, processed IMAP messages
-# will be moved (overruled by the --delete option!)
-$imapmovefolder = 'Inbox.processed';
+# If $imapmovefolder is set, processed IMAP messages will be moved (overruled by
+# the --delete option!)
+$imapmovefolder = 'dmarc/processed';
 
 # maximum size of XML files to store in database, long files can cause transaction aborts
 $maxsize_xml = 50000;

--- a/dmarcts-report-parser.conf.sample
+++ b/dmarcts-report-parser.conf.sample
@@ -10,25 +10,26 @@ $delete_reports = 0;
 
 $dbname = 'dmarc';
 $dbuser = 'dmarc';
-$dbpass = 'xxx';
-$dbhost = ''; # Set the hostname if we can't connect to the local socket.
+$dbpass = 'password';
+$dbhost = 'dbhost'; # Set the hostname if we can't connect to the local socket.
 $dbport = '3306';
 
-$imapserver       = 'mail.example.com:143';
-$imapuser         = 'dmarcreports';
-$imappass         = 'xxx';
+$imapserver       = 'imap.server';
+$imapuser         = 'username';
+$imappass         = 'password';
+$imapport         = '143';
 $imapssl          = '0';        # If set to 1, remember to change server port to 993 and disable imaptls.
-$imaptls          = '1';        # Enabled as the default and best-practice.
-$tlsverify        = '1';        # Enable verify server cert as the default and best-practice.
-$imapignoreerror  = 0;          # set it to 1 if you see an "ERROR: message_string() 
+$imaptls          = '0';        # Enabled as the default and best-practice.
+$tlsverify        = '0';        # Enable verify server cert as the default and best-practice.
+$imapignoreerror  = '0';          # set it to 1 if you see an "ERROR: message_string() 
                                 # expected 119613 bytes but received 81873 you may 
                                 # need the IgnoreSizeErrors option" because of malfunction
                                 # imap server as MS Exchange 2007, ...
-$imapreadfolder   = 'Inbox';
+$imapreadfolder   = 'dmarc';
 
 # If $imapmovefolder is set, processed IMAP messages will be moved (overruled by
 # the --delete option!)
-$imapmovefolder = 'Inbox.processed';
+$imapmovefolder = 'dmarc/processed';
 
 # maximum size of XML files to store in database, long files can cause transaction aborts
 $maxsize_xml = 50000;

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -156,7 +156,7 @@ if (!defined $imapignoreerror ) {
 # Get command line options.
 my %options = ();
 use constant { TS_IMAP => 0, TS_MESSAGE_FILE => 1, TS_XML_FILE => 2, TS_MBOX_FILE => 3 };
-GetOptions( \%options, 'd', 'r', 'x', 'm', 'e', 'i', 'delete', 'info' );
+GetOptions( \%options, 'd', 'r', 'x', 'm', 'e', 'i', 'z', 'delete', 'info' );
 
 # Evaluate command line options
 my $source_options = 0;

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -155,7 +155,7 @@ if (!defined $imapignoreerror ) {
   
 # Get command line options.
 my %options = ();
-use constant { TS_IMAP => 0, TS_MESSAGE_FILE => 1, TS_XML_FILE => 2, TS_MBOX_FILE => 3 };
+use constant { TS_IMAP => 0, TS_MESSAGE_FILE => 1, TS_XML_FILE => 2, TS_MBOX_FILE => 3, TS_ZIP_FILE => 4 };
 GetOptions( \%options, 'd', 'r', 'x', 'm', 'e', 'i', 'z', 'delete', 'info' );
 
 # Evaluate command line options


### PR DESCRIPTION
Attempting to use this with an on-prem Exchange environment using SSL, it kept throwing a bunch of errors related to the IMAP and SSL modules. Digging a bit into the various modules, I sussed out various settings needed to make this work. It no longer throws an SSL error, and is able to connect. Once that was solved, the script kept failing to grab the reports from the emails. Turns out, somehow, the imapignoreerror setting was never properly implemented. It's implemented now.