### PR TITLE
Add support parse zipped reports from PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ To install dependencies...
 
 ### on Debian:
 ```
-apt-get install libmail-imapclient-perl libmime-tools-perl libxml-simple-perl \
+apt-get install libfile-mimeinfo-perl libmail-imapclient-perl libmime-tools-perl libxml-simple-perl \
 libclass-dbi-mysql-perl libio-socket-inet6-perl libio-socket-ip-perl libperlio-gzip-perl \
 libmail-mbox-messageparser-perl unzip
 ```
 ### on Fedora (Fedora 23):
 ```
-sudo dnf install perl-Mail-IMAPClient perl-MIME-tools perl-XML-Simple perl-DBI \
+sudo dnf install perl-File-MimeInfo perl-Mail-IMAPClient perl-MIME-tools perl-XML-Simple perl-DBI \
  perl-Socket6 perl-PerlIO-gzip perl-DBD-MySQL unzip
 ```
 ### on CentOS (CentOS 7):
 ```
 yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum install perl-Mail-IMAPClient perl-MIME-tools perl-XML-Simple perl-DBI \
+yum install perl-File-MimeInfo perl-Mail-IMAPClient perl-MIME-tools perl-XML-Simple perl-DBI \
  perl-Socket6 perl-PerlIO-gzip perl-DBD-MySQL unzip perl-Mail-Mbox-MessageParser
  ```
 
@@ -104,6 +104,7 @@ One of the following source options must be provided:
 #        -m : Read reports from mbox file(s) provided in PATH.
 #        -e : Read reports from MIME email file(s) provided in PATH.
 #        -x : Read reports from xml file(s) provided in PATH.
+#        -z : Read reports from zip file(s) provided in PATH.
 ```
 
 The following options are always allowed:


### PR DESCRIPTION
Hello, I've modified parser to open archived (zip/gzip) reports from filesystem with `-z` option. It can be handy when you can't use IMAP and don't want to unzip reports manually.