### PR TITLE
Move failed dmarc msgs to a different IMAP folder than the successfully processed ones

### DIFF
--- a/dmarcts-report-parser.conf.sample
+++ b/dmarcts-report-parser.conf.sample
@@ -30,6 +30,10 @@ $imapreadfolder   = 'Inbox';
 # the --delete option!)
 $imapmovefolder = 'Inbox.processed';
 
+# If $imapmovefoldererr is set, IMAP messages that fail will be moved. If unset, failed messages
+# will move to $imapmovefolder (if it is set). Overruled by the --delete option!
+$imapmovefoldererr = 'Inbox.notProcessed';
+
 # maximum size of XML files to store in database, long files can cause transaction aborts
 $maxsize_xml = 50000;
 # store XML as base64 encopded gzip in database (save space, harder usable)

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -117,7 +117,8 @@ sub show_usage {
 # Define all possible configuration options.
 our ($debug, $delete_reports, $delete_failed, $reports_replace, $maxsize_xml, $compress_xml,
 	$dbname, $dbuser, $dbpass, $dbhost, $dbport,
-	$imapserver, $imapuser, $imappass, $imapignoreerror, $imapssl, $imaptls, $imapmovefolder, $imapreadfolder, $imapopt, $tlsverify);
+	$imapserver, $imapuser, $imappass, $imapignoreerror, $imapssl, $imaptls, $imapmovefolder,
+	$imapmovefoldererr, $imapreadfolder, $imapopt, $tlsverify);
 
 # defaults
 $maxsize_xml 	= 50000;
@@ -281,26 +282,16 @@ if ($reports_source == TS_IMAP) {
 				$imap->delete_message($msg)
 				or print "Could not delete IMAP message. [$@]\n";
 			} elsif ($imapmovefolder) {
-				print "Moving (copy and delete) processed IMAP message file to IMAP folder: $imapmovefolder\n" if $debug;
-
-				# Try to create $imapmovefolder, if it does not exist.
-				if (!$imap->exists($imapmovefolder)) {
-					$imap->create($imapmovefolder)
-					or print "Could not create IMAP folder: $imapmovefolder.\n";
+				if ($processResult & 1 || !$imapmovefoldererr) {
+					# processXML processed the XML OK, or it failed and there is no error imap folder
+					moveToImapFolder($imap, $msg, $imapmovefolder);
+				} elsif ($imapmovefoldererr) {
+					# processXML failed and error folder set
+					moveToImapFolder($imap, $msg, $imapmovefoldererr);
 				}
-
-				# Try to move the message to $imapmovefolder.
-				my $newid = $imap->copy($imapmovefolder, [ $msg ]);
-				if (!$newid) {
-					print "Error on moving (copy and delete) processed IMAP message: Could not COPY message to IMAP folder: <$imapmovefolder>!\n";
-					print "Messsage will not be moved/deleted. [$@]\n";
-				} else {
-					$imap->delete_message($msg)
-					or do {
-						print "Error on moving (copy and delete) processed IMAP message: Could not DELETE message\n";
-						print "after copying it to <$imapmovefolder>. [$@]\n";
-					}
-				}
+			} elsif ($imapmovefoldererr && !($processResult & 1)) {
+				# processXML failed, error imap folder set, but imapmovefolder unset. An unlikely setup, but still...
+				moveToImapFolder($imap, $msg, $imapmovefoldererr);
 			}
 		}
 
@@ -389,6 +380,33 @@ if ($reports_source == TS_IMAP) {
 ################################################################################
 ### subroutines ################################################################
 ################################################################################
+
+sub moveToImapFolder {
+	my $imap = $_[0];
+	my $msg = $_[1];
+	my $imapfolder = $_[2];
+
+	print "Moving (copy and delete) IMAP message file to IMAP folder: $imapfolder\n" if $debug;
+
+	# Try to create $imapfolder, if it does not exist.
+	if (!$imap->exists($imapfolder)) {
+		$imap->create($imapfolder)
+		or print "Could not create IMAP folder: $imapfolder.\n";
+	}
+
+	# Try to move the message to $imapfolder.
+	my $newid = $imap->copy($imapfolder, [ $msg ]);
+	if (!$newid) {
+		print "Error on moving (copy and delete) processed IMAP message: Could not COPY message to IMAP folder: <$imapfolder>!\n";
+		print "Messsage will not be moved/deleted. [$@]\n";
+	} else {
+		$imap->delete_message($msg)
+		or do {
+			print "Error on moving (copy and delete) processed IMAP message: Could not DELETE message\n";
+			print "after copying it to <$imapfolder>. [$@]\n";
+		}
+	}
+}
 
 sub processXML {
 	my $type = $_[0];


### PR DESCRIPTION
Added logic to allow a failed IMAP-read message to be moved to a separate IMAP folder than the folder with all the processed messages in it. If a message failed to parse, I wanted to be able to find it but not have it reprocessed next run.

Added a global $imapmovefoldererr; if it is unset then the code behaves exactly like it currently does.
