### PR TITLE
Update dmarcts-report-parser.pl: Allow multiple DKIM results to be evaluated

### DIFF
--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -814,19 +814,36 @@ sub storeXMLInDatabase {
 			$dkim = $rp->{'domain'};
 			$dkim = undef if ref $dkim eq "HASH";
 			$dkimresult = $rp->{'result'};
-		} else { # array
-			# glom sigs together, report first result
+		} else { # array, i.e. multiple dkim results (usually from multiple domains)
+			# glom sigs together
 			$dkim = join '/',map { my $d = $_->{'domain'}; ref $d eq "HASH"?"": $d } @$rp;
-			$dkimresult = $rp->[0]->{'result'};
-		}
-		$rp = $r{'auth_results'}->{'spf'};
-		if(ref $rp eq "HASH") {
-			$spf = $rp->{'domain'};
-			$spfresult = $rp->{'result'};
-		} else { # array
-			# glom domains together, report first result
-			$spf = join '/',map { my $d = $_->{'domain'}; ref $d eq "HASH"? "": $d } @$rp;
-			$spfresult = $rp->[0]->{'result'};
+			# report results
+			my $rp_len = scalar(@$rp);
+			for ( my $i=0; $i < $rp_len; $i++ ) {
+				if ( $rp->[$i]->{'result'} eq "pass" ) {
+					# If any one dkim result is a "pass", this should yield an overall "pass" and immediately exit the for loop, ignoring any remaing results
+					# See
+					# RFC 6376, DomainKeys Identified Mail (DKIM) Signatures
+					# 	Section 4.2: https://tools.ietf.org/html/rfc6376#section-4.2 and
+					# 	Section 6.1: https://tools.ietf.org/html/rfc6376#section-6.1
+					# And the GitHub issues at
+					#	https://github.com/techsneeze/dmarcts-report-viewer/issues/47
+					#	https://github.com/techsneeze/dmarcts-report-parser/pull/75
+					$dkimresult = "pass";
+					last;
+				} else {
+					for ( my $j=$i+1; $j < $rp_len; $j++ ) {
+						if ( $rp->[$i]->{'result'} eq $rp->[$j]->{'result'} ) {
+						# Compare each dkim result to the next one to see if all of the dkim results are the same.
+						# If all of the dkim results are the same, that will be the overall result.
+						# If any of them are different, and don't contain a "pass" result, then $dkimresult will be empty
+							$dkimresult = $rp->[0]->{'result'};
+						} else {
+							$dkimresult = undef;
+						}
+					}
+				}
+			}
 		}
 
 		$rp = $r{'row'}->{'policy_evaluated'}->{'reason'};

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -828,7 +828,7 @@ sub storeXMLInDatabase {
 					# 	Section 6.1: https://tools.ietf.org/html/rfc6376#section-6.1
 					# And the GitHub issues at
 					#	https://github.com/techsneeze/dmarcts-report-viewer/issues/47
-					#	https://github.com/techsneeze/dmarcts-report-parser/pull/75
+					#	https://github.com/techsneeze/dmarcts-report-parser/pull/78
 					$dkimresult = "pass";
 					last;
 				} else {


### PR DESCRIPTION
If a DMARC report includes more than one DKIM result, dmarcts-report-viewer only checks and reports the first one without regard to the other results.

This issue was first noted by @heraklit256 in techsneeze/dmarcts-report-viewer#47, but is actually more of a problem with 
dmarcts-report-parser.

@heraklit256 pointed to RFC 6376, DomainKeys Identified Mail (DKIM) Signatures, [Section 4.2](https://tools.ietf.org/html/rfc6376#section-4.2) which also references [Section 6.1](https://tools.ietf.org/html/rfc6376#section-6.1). Those two sections seem to suggest that, where there are multiple DKIM results, if any one is a "pass" then the overall DKIM result should be a pass, regardless of the other results.

This, to me, seems counter-intuitive but I guess it's the standard. If anyone has a different reading of those sections or an alternate view, please comment.

This pull request deals with this issue in this way:

* In the case where there are multiple DKIM results:
1. If any one result is a "pass" the overall DKIM result is a "pass"
1. If all the results are identical, then that is the overall DKIM result
1. If any of the results are different, and don't contain a "pass" result, then the overall DKIM result will be empty
