### PR TITLE
Avoid fatal error when there's no 'auth_results' in the XML

### DIFF
--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -813,6 +813,10 @@ sub storeXMLInDatabase {
 		my $identifier_hfrom = $r{'identifiers'}->{'header_from'};
 
 		my ($dkim, $dkimresult, $spf, $spfresult, $reason);
+		if(ref $r{'auth_results'} ne "HASH"){
+			print "Report has no auth_results data. Skipped.\n";
+			return 0;
+		}
 		my $rp = $r{'auth_results'}->{'dkim'};
 		if(ref $rp eq "HASH") {
 			$dkim = $rp->{'domain'};


### PR DESCRIPTION
Reports seen in the wild sometime lack actual 'auth_results' in the XML
which leads to

Can't use string ("") as a HASH ref while "strict refs" in use