### PR TITLE
Add PostgreSQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A Perl based tool to parse DMARC reports, based on John Levine's [rddmarc](http://www.taugh.com/rddmarc/), but extended by the following features:
 * Allow to read messages from an IMAP server and not only from the local filesystem.
 * Store much more XML values into the database (for example the missing SPF and DKIM results from the policy_evaluated section) and also the entire XML for later reference.
+* Supports MySQL and PostgreSQL.
 * Needed database tables and columns are created automatically, user only needs to provide a database. The database schema is compatible to the one used by rddmarc, but extends it by additional fields. Users can switch from rddmarc to dmarcts-report-parser without having to do any changes to the database by themselves.
 * Due to limitations in stock configurations of MySQL/MariaSQL on some distros, it may be necessary
 to add the following to your configuration (i.e. in /etc/mysql/mariadb.conf.d/50-server.cnf):
@@ -19,25 +20,28 @@ To install dependencies...
 ### on Debian:
 ```
 apt-get install libfile-mimeinfo-perl libmail-imapclient-perl libmime-tools-perl libxml-simple-perl \
-libclass-dbi-mysql-perl libio-socket-inet6-perl libio-socket-ip-perl libperlio-gzip-perl \
+libio-socket-inet6-perl libio-socket-ip-perl libperlio-gzip-perl \
 libmail-mbox-messageparser-perl unzip
 ```
+Plus `libdbd-mysql-perl` for MySQL or `libdbd-pg-perl` for PostgreSQL.
 ### on Fedora (Fedora 23):
 ```
 sudo dnf install perl-File-MimeInfo perl-Mail-IMAPClient perl-MIME-tools perl-XML-Simple perl-DBI \
- perl-Socket6 perl-PerlIO-gzip perl-DBD-MySQL unzip
+ perl-Socket6 perl-PerlIO-gzip unzip
 ```
+Plus `perl-DBD-MySQL` for MySQL or `perl-DBD-Pg` for PostgreSQL.
 ### on CentOS (CentOS 7):
 ```
 yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install perl-File-MimeInfo perl-Mail-IMAPClient perl-MIME-tools perl-XML-Simple perl-DBI \
- perl-Socket6 perl-PerlIO-gzip perl-DBD-MySQL unzip perl-Mail-Mbox-MessageParser
+ perl-Socket6 perl-PerlIO-gzip unzip perl-Mail-Mbox-MessageParser
  ```
+Plus `perl-DBD-MySQL` for MySQL or `perl-DBD-Pg` for PostgreSQL.
 ### on FreeBSD (FreeBSD 11.4):
 ```
-sudo pkg install p5-File-MimeInfo p5-Mail-IMAPClient p5-MIME-tools p5-XML-Simple p5-DBI p5-Socket6 p5-PerlIO-gzip p5-DBD-MySQL p5-Mail-Mbox-MessageParser unzip
+sudo pkg install p5-File-MimeInfo p5-Mail-IMAPClient p5-MIME-tools p5-XML-Simple p5-DBI p5-Socket6 p5-PerlIO-gzip p5-Mail-Mbox-MessageParser unzip
 ```
-
+Plus `p5-DBD-MySQL` for MySQL or `p5-DBD-Pg` for PostgreSQL.
  ### on macOS (macOS 10.13):
 ```
 brew install mysql shared-mime-info
@@ -45,8 +49,8 @@ update-mime-database /usr/local/share/mime
 perl -MCPAN -e 'install Mail::IMAPClient'
 perl -MCPAN -e 'install Mail::Mbox::MessageParser'
 perl -MCPAN -e 'install File::MimeInfo'
-perl -MCPAN -e 'install DBD::mysql'
 ```
+Plus `perl -MCPAN -e 'install DBD::mysql'` por MySQL or `perl -MCPAN -e 'install DBD::Pg'` or PostgreSQL.
 
 To get your copy of the dmarcts-report-parser, you can either clone the repository:
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ or download a zip file containg all files from [here](https://github.com/techsne
 $debug = 0;
 $delete_reports = 0;
 
+# Supported types: mysql, Pg. If unset, defaults to mysql
+#$dbtype = 'mysql';
 $dbname = 'dmarc';
 $dbuser = 'dmarc';
 $dbpass = 'password';

--- a/dbx_Pg.pl
+++ b/dbx_Pg.pl
@@ -4,6 +4,7 @@
 		my ($bin) = @_;
 		return "'\\x" . unpack("H*", $bin) . "'";
 	},
+	column_info_type_col => 'pg_type',
 );
 
 1;

--- a/dbx_Pg.pl
+++ b/dbx_Pg.pl
@@ -1,0 +1,9 @@
+%dbx = (
+	epoch_to_timestamp_fn => 'TO_TIMESTAMP',
+	to_hex_string => sub {
+		my ($bin) = @_;
+		return "'\\x" . unpack("H*", $bin) . "'";
+	},
+);
+
+1;

--- a/dbx_Pg.pl
+++ b/dbx_Pg.pl
@@ -1,10 +1,74 @@
 %dbx = (
 	epoch_to_timestamp_fn => 'TO_TIMESTAMP',
+
 	to_hex_string => sub {
 		my ($bin) = @_;
 		return "'\\x" . unpack("H*", $bin) . "'";
 	},
+
 	column_info_type_col => 'pg_type',
+
+	tables => {
+		"report" => {
+			column_definitions 		=> [
+				"serial"		, "bigint"			, "GENERATED ALWAYS AS IDENTITY",
+				"mindate"		, "timestamp without time zone"	, "NOT NULL",
+				"maxdate"		, "timestamp without time zone"	, "NULL",
+				"domain"		, "character varying(255)"	, "NOT NULL",
+				"org"			, "character varying(255)"	, "NOT NULL",
+				"reportid"		, "character varying(255)"	, "NOT NULL",
+				"email"			, "character varying(255)"	, "NULL",
+				"extra_contact_info"	, "character varying(255)"	, "NULL",
+				"policy_adkim"		, "character varying(20)"	, "NULL",
+				"policy_aspf"		, "character varying(20)"	, "NULL",
+				"policy_p"		, "character varying(20)"	, "NULL",
+				"policy_sp"		, "character varying(20)"	, "NULL",
+				"policy_pct"		, "smallint"			, "",
+				"raw_xml"		, "text"			, "",
+				],
+			additional_definitions 		=> "PRIMARY KEY (serial)",
+			table_options			=> "",
+			indexes				=> [
+				"CREATE UNIQUE INDEX report_uidx_domain ON report (domain, reportid);"
+				],
+			},
+		"rptrecord" => {
+			column_definitions 		=> [
+				"id"			, "bigint"						, "GENERATED ALWAYS AS IDENTITY",
+				"serial"		, "bigint"						, "NOT NULL",
+				"ip"			, "bigint"						, "",
+				"ip6"			, "bytea"						, "",
+				"rcount"		, "integer"						, "NOT NULL",
+				"disposition"		, "character varying(20)"				, "",
+				"reason"		, "character varying(255)"				, "",
+				"dkimdomain"		, "character varying(255)"				, "",
+				"dkimresult"		, "character varying(20)"				, "",
+				"spfdomain"		, "character varying(255)"				, "",
+				"spfresult"		, "character varying(20)"				, "",
+				"spf_align"		, "character varying(20)"				, "NOT NULL",
+				"dkim_align"		, "character varying(20)"				, "NOT NULL",
+				"identifier_hfrom"	, "character varying(255)"				, ""
+				],
+			additional_definitions 		=> "PRIMARY KEY (id)",
+			table_options			=> "",
+			indexes				=> [
+				"CREATE INDEX rptrecord_idx_serial ON rptrecord (serial, ip);",
+				"CREATE INDEX rptrecord_idx_serial6 ON rptrecord (serial, ip6);",
+				],
+			},
+		},
+
+	add_column => sub {
+		my ($table, $col_name, $col_type, $col_opts, $after_col) = @_;
+
+		# Postgres only allows adding columns at the end, so $after_col is ignored
+		return "ALTER TABLE $table ADD COLUMN $col_name $col_type $col_opts;"
+	},
+
+	modify_column => sub {
+		my ($table, $col_name, $col_type, $col_opts) = @_;
+		return "ALTER TABLE $table ALTER COLUMN $col_name TYPE $col_type;"
+	},
 );
 
 1;

--- a/dbx_mysql.pl
+++ b/dbx_mysql.pl
@@ -4,6 +4,7 @@
 		my ($bin) = @_;
 		return "X'" . unpack("H*", $bin) . "'";
 	},
+	column_info_type_col => 'mysql_type_name',
 );
 
 1;

--- a/dbx_mysql.pl
+++ b/dbx_mysql.pl
@@ -1,10 +1,72 @@
 %dbx = (
 	epoch_to_timestamp_fn => 'FROM_UNIXTIME',
+
 	to_hex_string => sub {
 		my ($bin) = @_;
 		return "X'" . unpack("H*", $bin) . "'";
 	},
+
 	column_info_type_col => 'mysql_type_name',
+
+	tables => {
+		"report" => {
+			column_definitions 		=> [
+				"serial"		, "int"			, "unsigned NOT NULL AUTO_INCREMENT",
+				"mindate"		, "timestamp"		, "NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+				"maxdate"		, "timestamp"		, "NULL",
+				"domain"		, "varchar(255)"	, "NOT NULL",
+				"org"			, "varchar(255)"	, "NOT NULL",
+				"reportid"		, "varchar(255)"	, "NOT NULL",
+				"email"			, "varchar(255)"	, "NULL",
+				"extra_contact_info"	, "varchar(255)"	, "NULL",
+				"policy_adkim"		, "varchar(20)"		, "NULL",
+				"policy_aspf"		, "varchar(20)"		, "NULL",
+				"policy_p"		, "varchar(20)"		, "NULL",
+				"policy_sp"		, "varchar(20)"		, "NULL",
+				"policy_pct"		, "tinyint"		, "unsigned",
+				"raw_xml"		, "mediumtext"		, "",
+				],
+			additional_definitions 		=> "PRIMARY KEY (serial), UNIQUE KEY domain (domain, reportid)",
+			table_options			=> "ROW_FORMAT=COMPRESSED",
+			indexes				=> [],
+			},
+		"rptrecord" => {
+			column_definitions 		=> [
+				"id"			, "int"	, "unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY",
+				"serial"		, "int"							, "unsigned NOT NULL",
+				"ip"			, "int"							, "unsigned",
+				"ip6"			, "binary(16)"						, "",
+				"rcount"		, "int"							, "unsigned NOT NULL",
+				"disposition"		, "enum('" . join("','", ALLOWED_DISPOSITION) . "')"	, "",
+				"reason"		, "varchar(255)"					, "",
+				"dkimdomain"		, "varchar(255)"					, "",
+				"dkimresult"		, "enum('" . join("','", ALLOWED_DKIMRESULT) . "')"	, "",
+				"spfdomain"		, "varchar(255)"					, "",
+				"spfresult"		, "enum('" . join("','", ALLOWED_SPFRESULT) . "')"	, "",
+				"spf_align"		, "enum('" . join("','", ALLOWED_SPF_ALIGN) . "')"	, "NOT NULL",
+				"dkim_align"		, "enum('" . join("','", ALLOWED_DKIM_ALIGN) . "')"	, "NOT NULL",
+				"identifier_hfrom"	, "varchar(255)"					, ""
+				],
+			additional_definitions 		=> "KEY serial (serial, ip), KEY serial6 (serial, ip6)",
+			table_options			=> "",
+			indexes				=> [],
+			},
+		},
+
+	add_column => sub {
+		my ($table, $col_name, $col_type, $col_opts, $after_col) = @_;
+
+		my $insert_pos = "FIRST";
+		if ($after_col) {
+			$insert_pos = "AFTER $after_col";
+		}
+		return "ALTER TABLE $table ADD $col_name $col_type $col_opts $insert_pos;"
+	},
+
+	modify_column => sub {
+		my ($table, $col_name, $col_type, $col_opts) = @_;
+		return "ALTER TABLE $table MODIFY COLUMN $col_name $col_type $col_opts;"
+	},
 );
 
 1;

--- a/dbx_mysql.pl
+++ b/dbx_mysql.pl
@@ -1,0 +1,9 @@
+%dbx = (
+	epoch_to_timestamp_fn => 'FROM_UNIXTIME',
+	to_hex_string => sub {
+		my ($bin) = @_;
+		return "X'" . unpack("H*", $bin) . "'";
+	},
+);
+
+1;

--- a/dmarcts-report-parser.conf.sample
+++ b/dmarcts-report-parser.conf.sample
@@ -8,6 +8,8 @@
 $debug = 0;
 $delete_reports = 0;
 
+# Supported types: mysql, Pg. If unset, defaults to mysql
+#$dbtype = 'mysql';
 $dbname = 'dmarc';
 $dbuser = 'dmarc';
 $dbpass = 'password';

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -837,8 +837,8 @@ sub storeXMLInDatabase {
 		}
 	}
 
-	my $sql = qq{INSERT INTO report(serial,mindate,maxdate,domain,org,reportid,email,extra_contact_info,policy_adkim, policy_aspf, policy_p, policy_sp, policy_pct, raw_xml)
-			VALUES(NULL,FROM_UNIXTIME(?),FROM_UNIXTIME(?),?,?,?,?,?,?,?,?,?,?,?)};
+	my $sql = qq{INSERT INTO report(mindate,maxdate,domain,org,reportid,email,extra_contact_info,policy_adkim, policy_aspf, policy_p, policy_sp, policy_pct, raw_xml)
+			VALUES(FROM_UNIXTIME(?),FROM_UNIXTIME(?),?,?,?,?,?,?,?,?,?,?,?)};
 	my $storexml = $xml->{'raw_xml'};
 	if ($compress_xml) {
 		my $gzipdata;
@@ -860,7 +860,7 @@ sub storeXMLInDatabase {
 		return 0;
 	}
 
-	my $serial = $dbh->{'mysql_insertid'} ||  $dbh->{'insertid'};
+	my $serial = $dbh->last_insert_id(undef, undef, 'report', undef);
 	if ($debug){
 		print " serial $serial \n";
 	}

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -1148,10 +1148,7 @@ sub checkDatabase {
 		} else {
 
 			#Table exists, get  current columns in this table from DB.
-			my %db_col_exists = ();
-			for ( @{ $dbh->selectall_arrayref( "SHOW COLUMNS FROM $table;") } ) {
-				$db_col_exists{$_->[0]} = $_->[1];
-			};
+			my %db_col_exists = db_column_info($dbh, $table);
 
 			# Check if all needed columns are present, if not add them at the desired position.
 			my $insert_pos = "FIRST";
@@ -1185,4 +1182,18 @@ sub db_tbl_exists {
 
 	my @res = $dbh->tables(undef, undef, $table, undef);
 	return scalar @res > 0;
+}
+
+################################################################################
+
+# Gets columns and their data types in a given table
+sub db_column_info {
+	my ($dbh, $table) = @_;
+
+	my $db_info = $dbh->column_info(undef, undef, $table, undef)->fetchall_hashref('COLUMN_NAME');
+	my %columns;
+	foreach my $column (keys(%$db_info)) {
+		$columns{$column} = $db_info->{$column}{$dbx{column_info_type_col}};
+	}
+	return %columns;
 }

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -118,12 +118,13 @@ sub show_usage {
 
 # Define all possible configuration options.
 our ($debug, $delete_reports, $delete_failed, $reports_replace, $maxsize_xml, $compress_xml,
-	$dbname, $dbuser, $dbpass, $dbhost, $dbport, $db_tx_support,
+	$dbtype, $dbname, $dbuser, $dbpass, $dbhost, $dbport, $db_tx_support,
   $imapserver, $imapport, $imapuser, $imappass, $imapignoreerror, $imapssl, $imaptls, $imapmovefolder,
 	$imapmovefoldererr, $imapreadfolder, $imapopt, $tlsverify, $processInfo);
 
 # defaults
 $maxsize_xml 	= 50000;
+$dbtype = 'mysql';
 $db_tx_support	= 1;
 
 # used in messages
@@ -263,7 +264,7 @@ if (exists $options{delete}) {$delete_reports = 1;}
 if (exists $options{info}) {$processInfo = 1;}
 
 # Setup connection to database server.
-my $dbh = DBI->connect("DBI:mysql:database=$dbname;host=$dbhost;port=$dbport",
+my $dbh = DBI->connect("DBI:$dbtype:database=$dbname;host=$dbhost;port=$dbport",
 	$dbuser, $dbpass)
 or die "$scriptname: Cannot connect to database\n";
 checkDatabase($dbh);

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -1119,16 +1119,10 @@ sub checkDatabase {
 			},
 	);
 
-	# Get current tables in this DB.
-	my %db_tbl_exists = ();
-	for ( @{ $dbh->selectall_arrayref( "SHOW TABLES;") } ) {
-		$db_tbl_exists{$_->[0]} = 1;
-	}
-
 	# Create missing tables and missing columns.
 	for my $table ( keys %tables ) {
 
-		if (!$db_tbl_exists{$table}) {
+		if (!db_tbl_exists($dbh, $table)) {
 
 			# Table does not exist, build CREATE TABLE cmd from tables hash.
 			print "$scriptname: Adding missing table <" . $table . "> to the database.\n";
@@ -1181,4 +1175,14 @@ sub checkDatabase {
 			}
 		}
 	}
+}
+
+################################################################################
+
+# Checks if the table exists in the database
+sub db_tbl_exists {
+	my ($dbh, $table) = @_;
+
+	my @res = $dbh->tables(undef, undef, $table, undef);
+	return scalar @res > 0;
 }


### PR DESCRIPTION
This adds support for PostgreSQL in addition to MySQL.

Changing the insertion was quite simple, but the table creation/updating code required bigger changes, as each DB has different opinions on data types and DDL commands.

The code is structured in a way that it should be easy to add support for sqlite (and other DBs), but I haven't tried doing that.

I removed some code for MySQL <= 5 that output `int(10)` instead of just `int` in newer versions, since I don't think there are many people running MySQL 5. But I could add it back if you prefer.