### PR TITLE
Deduplicate reports over (domain, org, reportid), not just over reportid

### DIFF
--- a/dbx_Pg.pl
+++ b/dbx_Pg.pl
@@ -29,7 +29,7 @@
 			additional_definitions 		=> "PRIMARY KEY (serial)",
 			table_options			=> "",
 			indexes				=> [
-				"CREATE UNIQUE INDEX report_uidx_domain ON report (domain, reportid);"
+				"CREATE UNIQUE INDEX report_uidx_domain ON report (domain, org, reportid);"
 				],
 			},
 		"rptrecord" => {

--- a/dbx_mysql.pl
+++ b/dbx_mysql.pl
@@ -26,7 +26,7 @@
 				"policy_pct"		, "tinyint"		, "unsigned",
 				"raw_xml"		, "mediumtext"		, "",
 				],
-			additional_definitions 		=> "PRIMARY KEY (serial), UNIQUE KEY domain (domain, reportid)",
+			additional_definitions 		=> "PRIMARY KEY (serial), UNIQUE KEY domain (domain, org, reportid)",
 			table_options			=> "ROW_FORMAT=COMPRESSED",
 			indexes				=> [],
 			},

--- a/dmarcts-report-parser.pl
+++ b/dmarcts-report-parser.pl
@@ -813,8 +813,8 @@ sub storeXMLInDatabase {
 	}
 
 	# see if already stored
-	my $sth = $dbh->prepare(qq{SELECT org, serial FROM report WHERE reportid=?});
-	$sth->execute($id);
+	my $sth = $dbh->prepare(qq{SELECT org, serial FROM report WHERE reportid=? AND org=? AND domain=?});
+	$sth->execute($id, $org, $domain);
 	while ( my ($xorg,$sid) = $sth->fetchrow_array() )
 	{
 		if ($reports_replace) {


### PR DESCRIPTION
This pull request closes #112.

WARNING: The scheme of a running database must be changed to use the new index definition. Example for MySQL:
ALTER TABLE report DROP INDEX domain, ADD UNIQUE KEY domain (domain, org, reportid);

Any idea to automate this?

Without this change, the following failure will occur when encountering an identical (domain, reportid) tuple:
DBD::mysql::db do failed: Duplicate entry 'wander.science-wander.science.1677801600.1677888000' for key 'domain' at dmarcts-report-parser.pl line 859.
dmarcts-report-parser.pl: aperture-labs.org: wander.science.1677801600.1677888000: Cannot add report to database. Skipped.
dmarcts-report-parser.pl: Skipping IMAP message with UID #2869 due to database errors.
